### PR TITLE
refactor: use flag variables for floor and ceiling color validation

### DIFF
--- a/includes/parser.h
+++ b/includes/parser.h
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   parser.h                                           :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
+/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/10/06 01:00:00 by jlacerda          #+#    #+#             */
-/*   Updated: 2025/11/01 17:13:20 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/11/15 20:03:43 by peda-cos         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -84,6 +84,8 @@ typedef struct s_config
 	t_textures	textures;
 	t_color		floor_color;
 	t_color		ceiling_color;
+	int			floor_color_set;
+	int			ceiling_color_set;
 }				t_config;
 
 int				normalize_map(t_map *map);

--- a/sources/parser/parse_headers.c
+++ b/sources/parser/parse_headers.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   parse_headers.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
+/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/22 05:24:28 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/10/31 22:47:19 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/11/15 20:03:43 by peda-cos         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -159,9 +159,9 @@ int	parse_headers(int fd, t_config *cfg, char **line_after_headers)
 		return (parser_error("missing WE texture"));
 	if (!cfg->textures.ea_path)
 		return (parser_error("missing EA texture"));
-	if (cfg->floor_color.rgba == -1)
+	if (!cfg->floor_color_set)
 		return (parser_error("missing F color"));
-	if (cfg->ceiling_color.rgba == -1)
+	if (!cfg->ceiling_color_set)
 		return (parser_error("missing C color"));
 	return (0);
 }

--- a/sources/parser/parse_headers_utils.c
+++ b/sources/parser/parse_headers_utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   parse_headers_utils.c                              :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
+/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/22 09:01:48 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/10/23 22:09:42 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/11/15 20:03:43 by peda-cos         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -85,17 +85,19 @@ static int	handle_color_line(char *id, t_config *cfg)
 		rest++;
 	if (id[0] == 'F')
 	{
-		if (cfg->floor_color.rgba != -1)
+		if (cfg->floor_color_set)
 			return (parser_error("duplicate color identifier"));
 		if (parse_color(rest, &cfg->floor_color) < 0)
 			return (-1);
+		cfg->floor_color_set = 1;
 	}
 	else if (id[0] == 'C')
 	{
-		if (cfg->ceiling_color.rgba != -1)
+		if (cfg->ceiling_color_set)
 			return (parser_error("duplicate color identifier"));
 		if (parse_color(rest, &cfg->ceiling_color) < 0)
 			return (-1);
+		cfg->ceiling_color_set = 1;
 	}
 	return (0);
 }

--- a/sources/parser/parser_utils.c
+++ b/sources/parser/parser_utils.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   parser_utils.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: jlacerda <jlacerda@student.42.fr>          +#+  +:+       +#+        */
+/*   By: peda-cos <peda-cos@student.42sp.org.br>    +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2025/08/22 05:23:48 by peda-cos          #+#    #+#             */
-/*   Updated: 2025/11/01 17:31:29 by jlacerda         ###   ########.fr       */
+/*   Updated: 2025/11/15 20:03:43 by peda-cos         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -55,6 +55,8 @@ void	init_config_values(t_config *cfg)
 	cfg->textures.sprite_count = 0;
 	cfg->floor_color.rgba = -1;
 	cfg->ceiling_color.rgba = -1;
+	cfg->floor_color_set = 0;
+	cfg->ceiling_color_set = 0;
 	cfg->map.grid = NULL;
 	cfg->map.width = 0;
 	cfg->map.height = 0;


### PR DESCRIPTION
Replace RGBA value checks against -1 with dedicated boolean flags to improve code clarity and separation of concerns. Add floor_color_set and ceiling_color_set fields to t_config struct, initialize them in init_config_values(), and update validation logic in parse_headers() and handle_color_line() to use these flags instead of checking color values directly.